### PR TITLE
fixes const/constexpr make warnings

### DIFF
--- a/example/events/inbound.hpp
+++ b/example/events/inbound.hpp
@@ -11,7 +11,7 @@ struct inbound {
 
   //// Member Variables ///////////
 
-    static constexpr char * description = "sbe market data";
+    static constexpr const char * description = "sbe market data";
 
     // Inbound sbe market data event fields from tshark csv
     omi::frame frame;              // Pcap frame number

--- a/example/events/outbound.hpp
+++ b/example/events/outbound.hpp
@@ -12,7 +12,7 @@ struct outbound {
   //// Member Variables ///////////
 
     // Event description
-    static constexpr char * description = "ilink fix message";
+    static constexpr const char * description = "ilink fix message";
 
     // Outbound triggered event fields (cme fix)
     omi::frame frame;

--- a/omi/latency/analysis.hpp
+++ b/omi/latency/analysis.hpp
@@ -13,9 +13,9 @@ namespace analysis {
 
 // Default analysis program template notes 
 struct description {
-    static constexpr char * title = "Latency Analysis";
-    static constexpr char * inbound = "events";
-    static constexpr char * outbound = "responses";
+    static constexpr const char * title = "Latency Analysis";
+    static constexpr const char * inbound = "events";
+    static constexpr const char * outbound = "responses";
 };
 
 template <class inbound, class outbound, class description = description>

--- a/omi/latency/comparison.hpp
+++ b/omi/latency/comparison.hpp
@@ -14,9 +14,9 @@ namespace comparison {
 
 // Default comparison program template notes 
 struct description {
-    static constexpr char * title = "Latency Comparison Report";
-    static constexpr char * inbound = "events";
-    static constexpr char * outbound = "responses";
+    static constexpr const char * title = "Latency Comparison Report";
+    static constexpr const char * inbound = "events";
+    static constexpr const char * outbound = "responses";
 };
 
 // Latency comparison html report program template


### PR DESCRIPTION
Fix for `make` warning:

`ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]`
