### PR TITLE
Constexpr

### DIFF
--- a/example/email/main.cpp
+++ b/example/email/main.cpp
@@ -54,9 +54,9 @@ struct fix {
 
 struct description {
   // Program description
-    static constexpr char * title = "Emailable Latency Report for Cme Tick to Trade";
-    static constexpr char * inbound = "sbe mdp market data events";
-    static constexpr char * outbound = "ilink fix messages";
+    static constexpr const char * title = "Emailable Latency Report for Cme Tick to Trade";
+    static constexpr const char * inbound = "sbe mdp market data events";
+    static constexpr const char * outbound = "ilink fix messages";
 };
 
 int main(int argc, char *argv[]) {

--- a/example/report/cme/fix.hpp
+++ b/example/report/cme/fix.hpp
@@ -12,7 +12,7 @@ struct fix {
   //// Member Variables ///////////
 
     // Event description
-    static constexpr char * description = "ilink fix message";
+    static constexpr const char * description = "ilink fix message";
 
     // Outbound triggered event fields (cme fix)
     omi::frame frame;

--- a/example/report/cme/sbe.hpp
+++ b/example/report/cme/sbe.hpp
@@ -11,7 +11,7 @@ struct sbe {
 
   //// Member Variables ///////////
 
-    static constexpr char * description = "sbe mdp market data";
+    static constexpr const char * description = "sbe mdp market data";
 
     // Inbound sbe market data event fields from tshark csv
     omi::frame frame;              // Pcap frame number

--- a/omi/latency/email.hpp
+++ b/omi/latency/email.hpp
@@ -14,9 +14,9 @@ namespace email {
 
 // Default email program template notes 
 struct description {
-    static constexpr char * title = "Generate Emailable Latency Report";
-    static constexpr char * inbound = "events";
-    static constexpr char * outbound = "responses";
+    static constexpr const char * title = "Generate Emailable Latency Report";
+    static constexpr const char * inbound = "events";
+    static constexpr const char * outbound = "responses";
 };
 
 // Latency report program template

--- a/omi/latency/matching.hpp
+++ b/omi/latency/matching.hpp
@@ -12,9 +12,9 @@ namespace matching {
 
     // Default email program template notes 
 struct description {
-    static constexpr char * title = "Matched Event List";
-    static constexpr char * inbound = "events";
-    static constexpr char * outbound = "responses";
+    static constexpr const char * title = "Matched Event List";
+    static constexpr const char * inbound = "events";
+    static constexpr const char * outbound = "responses";
 };
 
 template <class inbound, class outbound, class description = description>


### PR DESCRIPTION
Fixes constexpr warnings at compile time

As stated in the warning messages we've been getting when running make, "ISO C++ forbids converting a string constant to 'char*' ".

We have changed several uses of "constexpr" to "constexpr const" to conform with the standard.