### PR TITLE
use prebuilt cmake on travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,15 @@ dist: trusty
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
-
-install: 
   - sudo apt-get install -qq g++-8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
 
-  # cmake 3.11
-  - wget https://cmake.org/files/v3.11/cmake-3.11.4.tar.gz
-  - tar -zxf cmake-3.11.4.tar.gz
-  - cd cmake-3.11.4
-  - ./bootstrap
-  - make -s
-  - sudo make install
+  # cmake
+  - wget https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.sh
+  - wget https://cmake.org/files/v3.12/cmake-3.12.1-SHA-256.txt
+  - grep cmake-3.12.1-Linux-x86_64.sh cmake-3.12.1-SHA-256.txt | shasum -c -
+  - sudo sh cmake-3.12.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
   - cmake --version
-  - cd ..
 
   # boost 1.67
   - wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.gz
@@ -32,12 +27,13 @@ install:
   - ./bootstrap.sh --with-libraries=program_options,filesystem,system
   - ./b2 -d0
   - sudo ./b2 install -d0
-
-before_script:  
-  - export PATH=/usr/local/bin:$PATH
   - cd ..
+
+install:
+  - export PATH=/usr/local/bin:$PATH
   - mkdir build
   - cd build
+  - cmake --version
   - cmake ..
 
 script: make


### PR DESCRIPTION
Using prebuilt cmake, shaved down build time from 17 to 5 min. There end up being two `cmake` binaries installed on the system, 3.9 in /usr/bin (part of the default cpp setup environment for travis),  and 3.12 in /usr/local/bin. It could be a little cleaner. 

I also moved most of the dependency stuff into `before_install` section.